### PR TITLE
fix: If draft trait is not used on record but used in form

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ComposerSettings">
+    <execution />
+  </component>
+</project>

--- a/src/FilamentSimpleDraftServiceProvider.php
+++ b/src/FilamentSimpleDraftServiceProvider.php
@@ -27,7 +27,11 @@ class FilamentSimpleDraftServiceProvider extends PackageServiceProvider
     public function registerComponentMacros(): void
     {
         Field::macro('draftable', function (string $key = 'is_published') {
-            $this->nullable(fn ($livewire) => $livewire->shouldSaveAsDraft);
+            $this->nullable(function ($livewire) {
+                return property_exists($livewire, 'shouldSaveAsDraft')
+                    ? $livewire->shouldSaveAsDraft
+                    : true;
+            });
 
             return $this;
         });


### PR DESCRIPTION
If draft trait is not used on record but used in form this should be default to `->nullable(true)`.